### PR TITLE
Display service file (image) for collection objects.

### DIFF
--- a/config/install/core.entity_view_display.node.islandora_object.collection.yml
+++ b/config/install/core.entity_view_display.node.islandora_object.collection.yml
@@ -71,25 +71,29 @@ content:
     third_party_settings: {  }
     weight: 4
     region: content
+  display_media_service_file:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
   field_description:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 0
+    weight: 1
     region: content
   field_note:
     type: basic_string
     label: inline
     settings: {  }
     third_party_settings: {  }
-    weight: 1
+    weight: 2
     region: content
 hidden:
   addtoany: true
   display_media_entity_view_1: true
   display_media_entity_view_2: true
-  display_media_service_file: true
   display_media_thumbnail: true
   field_access_terms: true
   field_alternative_title: true


### PR DESCRIPTION
How to test:

1. visit: http://localhost:8000/admin/structure/types/manage/islandora_object/display
2. Move "EVA: Media EVAs - Service File" to the top, and click save.
3. Visit: http://localhost:8000/media/add/image?edit[field_media_of][widget][0][target_id]=48
4. Add an image, and select "Service File" and click save.
5. Vist: http://localhost:8000/node/48

Or...

1. Change `yorkulibraries/yudl_defaults:2.x-dev` [here](https://github.com/yorkulibraries/yudl-playbook/blob/main/inventory/dev/group_vars/webserver/drupal.yml#L33) to `yorkulibraries/yudl_defaults:york_drupal_theme-issues-18-dev`
2. `vagrant destroy; vagrant up`
3. Do steps 3-5 above.

You should get something like this depending on the size of the image:
![Screenshot 2023-01-25 at 08-40-21 Toronto Telegram YUDL DEV](https://user-images.githubusercontent.com/218561/214578554-2cbddbd5-df2a-4b11-9d19-4dc4e6e37f01.png)
