### PR TITLE
Add Date slider facet.

### DIFF
--- a/modules/islandora_search/config/install/facets.facet.year.yml
+++ b/modules/islandora_search/config/install/facets.facet.year.yml
@@ -1,0 +1,67 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - search_api.index.default_solr_index
+    - views.view.solr_search_content
+  module:
+    - search_api
+id: year
+name: Year
+weight: 0
+min_count: 1
+missing: false
+missing_label: others
+url_alias: year
+facet_source_id: 'search_api:views_page__solr_search_content__page_1'
+field_identifier: edtf_year
+query_operator: or
+hard_limit: 0
+exclude: false
+use_hierarchy: false
+keep_hierarchy_parents_active: false
+hierarchy:
+  type: taxonomy
+  config: {  }
+expand_hierarchy: false
+enable_parent_when_child_gets_disabled: true
+widget:
+  type: range_slider
+  config:
+    show_numbers: false
+    prefix: ''
+    suffix: ''
+    min_type: search_result
+    min_value: !!float 0
+    max_type: search_result
+    max_value: !!float 10
+    step: !!float 1
+empty_behavior:
+  behavior: none
+only_visible_when_facet_source_is_visible: true
+show_only_one_result: true
+show_title: false
+processor_configs:
+  hierarchy_processor:
+    processor_id: hierarchy_processor
+    weights:
+      build: 100
+    settings: {  }
+  range_slider:
+    processor_id: range_slider
+    weights:
+      pre_query: 60
+      post_query: 60
+      build: 20
+    settings: {  }
+  slider:
+    processor_id: slider
+    weights:
+      post_query: 60
+    settings: {  }
+  url_processor_handler:
+    processor_id: url_processor_handler
+    weights:
+      pre_query: 50
+      build: 15
+    settings: {  }

--- a/modules/islandora_search/config/install/search_api.index.default_solr_index.yml
+++ b/modules/islandora_search/config/install/search_api.index.default_solr_index.yml
@@ -2,16 +2,21 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.taxonomy_term.field_cat_date_begin
+    - field.storage.taxonomy_term.field_cat_date_end
     - field.storage.node.field_city
     - field.storage.node.field_city_section
     - field.storage.node.field_continent
+    - field.storage.taxonomy_term.field_corp_alt_name
     - field.storage.node.field_country
     - field.storage.node.field_county
+    - field.storage.node.field_description
     - field.storage.node.field_edtf_date
     - field.storage.node.field_edtf_date_created
     - field.storage.node.field_edtf_date_issued
-    - field.storage.node.field_description
     - field.storage.node.field_genre
+    - field.storage.taxonomy_term.field_geo_alt_name
+    - field.storage.node.field_geographic_subject
     - field.storage.node.field_language
     - field.storage.node.field_linked_agent
     - field.storage.node.field_member_of
@@ -21,14 +26,9 @@ dependencies:
     - field.storage.node.field_region
     - field.storage.node.field_resource_type
     - field.storage.node.field_subject
-    - field.storage.node.field_geographic_subject
     - field.storage.node.field_subjects_name
     - field.storage.node.field_tags
     - field.storage.node.field_temporal_subject
-    - field.storage.taxonomy_term.field_geo_alt_name
-    - field.storage.taxonomy_term.field_corp_alt_name
-    - field.storage.taxonomy_term.field_cat_date_end
-    - field.storage.taxonomy_term.field_cat_date_begin
     - search_api.server.default_solr_server
     - core.entity_view_mode.node.search_index
   module:
@@ -37,6 +37,7 @@ dependencies:
     - user
     - taxonomy
     - search_api
+    - controlled_access_terms
     - media
 third_party_settings:
   search_api_solr:
@@ -144,6 +145,10 @@ field_settings:
     dependencies:
       module:
         - taxonomy
+  edtf_year:
+    label: Year
+    property_path: edtf_year
+    type: integer
   field_cat_date_begin:
     label: 'Founding Date'
     datasource_id: 'entity:taxonomy_term'
@@ -522,6 +527,17 @@ processor_settings:
     weights:
       preprocess_index: -6
       preprocess_query: -4
+  edtf_year_only:
+    fields:
+      islandora_object|field_date_modified_: islandora_object|field_date_modified_
+      islandora_object|field_edtf_date: islandora_object|field_edtf_date
+      islandora_object|field_edtf_date_created: islandora_object|field_edtf_date_created
+      islandora_object|field_edtf_date_issued: islandora_object|field_edtf_date_issued
+    ignore_undated: 1
+    ignore_open_start: 1
+    open_start_year: '0'
+    ignore_open_end: 1
+    open_end_year: ''
   entity_status:
     weights:
       preprocess_index: -10


### PR DESCRIPTION
- Partially addresses #32

Depends on:
  - https://github.com/yorkulibraries/york_drupal_theme/pull/30
  - https://github.com/yorkulibraries/yudl-playbook/pull/55

How to test:

Option 1:

1. Rebuild by checking out in 
2. Change `yorkulibraries/yudl_defaults:2.x-dev` to `yorkulibraries/yudl_defaults:dev-issue-32` in `inventory/dev/group_vars/webserver/drupal.yml`
3. Change `version: main` to `version: yudl_defaults-issues-32` in `install-york-theme.yml`
4. `vagrant box update; vagrant destroy; vagrant up`
5. Visit http://localhost:8000/solr-search/content?search_api_fulltext

Option 2:

1. `composer require 'drupal/jquery_ui_slider:^2.0'`
2. `composer require 'drupal/jquery_ui_touch_punch:^1.1'`
    - Do this as www-data user or chown "/var/www/html/drupal/web/libraries" to vagrant:vagrant
3. `drush en -y jquery_ui_slider facets_range_widget`
4. `cd /var/www/html/drupal/web/libraries`
5 `git clone https://github.com/simeydotme/jQuery-ui-Slider-Pips.git`
7. `mv jQuery-ui-Slider-Pips jquery-ui-slider-pips`
8. Put `modules/islandora_search/config/install/facets.facet.year.yml` and `modules/islandora_search/config/install/search_api.index.default_solr_index.yml` in a directory (/tmp/issue-32-test)
9. `cd /var/www/html/drupal`
9 . `drush cim -y --partial --source=/tmp/issue-28-test`
10. Visit http://localhost:8000/solr-search/content?search_api_fulltext

![Screenshot 2023-02-12 at 23-13-24 Search Results YUDL DEV](https://user-images.githubusercontent.com/218561/218456627-65130fdf-ce15-4695-aede-edcf6079b5dd.png)
